### PR TITLE
fix: Use public API to calculate page instead of now removed private function

### DIFF
--- a/selection-grid-pro-flow/src/main/resources/META-INF/resources/frontend/src/helpers.js
+++ b/selection-grid-pro-flow/src/main/resources/META-INF/resources/frontend/src/helpers.js
@@ -109,7 +109,8 @@ export function _getItemOverriden(index, el) {
         }
     } else {
         this.toggleAttribute("loading", true, el);
-        this._loadPage(this._getPageForIndex(scaledIndex), cache);
+        const page = Math.floor(scaledIndex / this.pageSize);
+        this._loadPage(page, cache);
     }
     /** focus when get item if there is an item to focus **/
     if (this._rowNumberToFocus > -1) {


### PR DESCRIPTION
The same as https://github.com/vaadin-component-factory/selection-grid-flow/pull/48/files