### PR TITLE
feat: add support for persistent checkbox multi selection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>selection-grid-pro-flow-root</artifactId>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>selection-grid-pro-flow</module>

--- a/selection-grid-pro-flow-demo/pom.xml
+++ b/selection-grid-pro-flow-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>selection-grid-pro-flow-demo</artifactId>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <name>Selection Grid Pro Demo</name>
     <packaging>war</packaging>

--- a/selection-grid-pro-flow-demo/src/main/java/com/vaadin/componentfactory/selectiongridpro/LazyDataView.java
+++ b/selection-grid-pro-flow-demo/src/main/java/com/vaadin/componentfactory/selectiongridpro/LazyDataView.java
@@ -1,16 +1,17 @@
 package com.vaadin.componentfactory.selectiongridpro;
 
+import java.util.stream.Stream;
+
 import com.vaadin.componentfactory.selectiongridpro.bean.Person;
 import com.vaadin.componentfactory.selectiongridpro.service.PersonService;
+import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.grid.Grid;
-import com.vaadin.flow.component.gridpro.GridPro;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.data.provider.AbstractBackEndDataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.router.Route;
-
-import java.util.stream.Stream;
 
 @Route(value = "lazy", layout = MainLayout.class)
 public class LazyDataView extends VerticalLayout
@@ -23,9 +24,22 @@ public class LazyDataView extends VerticalLayout
     {
         Div messageDiv = new Div();
 
-        GridPro<Person> grid = new SelectionGridPro<>();
+        SelectionGridPro<Person> grid = new SelectionGridPro<>();
         grid.setDataProvider(personDataProvider);
-
+        Checkbox changeMultiselectionColumn = new Checkbox("Multiselection column");
+		changeMultiselectionColumn.addValueChangeListener(event -> {
+			grid.setMultiSelectionColumnVisible(event.getValue());
+		});
+		Checkbox persistentCheckboxSelection = new Checkbox("Persistent selection");
+		persistentCheckboxSelection.setValue(true);
+		persistentCheckboxSelection.addValueChangeListener(event -> {
+			grid.setPersistentCheckboxSelection(event.getValue());
+		});
+		persistentCheckboxSelection.setTooltipText("When enabled, selecting a row via its checkbox will "
+				+ "add or remove it from the current selection without clearing previously selected rows. "
+				+ "This behavior allows users to manage selections manually using checkboxes, "
+				+ "similar to how email clients like Gmail handle selection");
+		
         grid.addEditColumn(Person::getFirstName).text(Person::setFirstName).setHeader("First Name");
         grid.addEditColumn(Person::getLastName).text(Person::setLastName).setHeader("Last Name");
         grid.addColumn(Person::getAge).setHeader("Age");
@@ -40,7 +54,7 @@ public class LazyDataView extends VerticalLayout
         });
 
         // You can pre-select items
-        add(grid, messageDiv);
+        add(new HorizontalLayout(changeMultiselectionColumn,persistentCheckboxSelection), grid, messageDiv);
     }
 
     public static class PersonDataProvider extends AbstractBackEndDataProvider<Person, String> {

--- a/selection-grid-pro-flow/pom.xml
+++ b/selection-grid-pro-flow/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>selection-grid-pro-flow</artifactId>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Selection GridPro</name>

--- a/selection-grid-pro-flow/src/main/resources/META-INF/resources/frontend/src/helpers.js
+++ b/selection-grid-pro-flow/src/main/resources/META-INF/resources/frontend/src/helpers.js
@@ -38,7 +38,10 @@ export function _debounce(func, wait, immediate) {
 };
 
 export function _selectionGridSelectRowWithItem(e, item, index) {
-    const ctrlKey = (e.metaKey)?e.metaKey:e.ctrlKey; //(this._ios)?e.metaKey:e.ctrlKey;
+    let ctrlKey = (e.metaKey)?e.metaKey:e.ctrlKey; //(this._ios)?e.metaKey:e.ctrlKey;
+    if (!this.classicCheckboxSelection && e.srcElement && e.srcElement.parentNode && e.srcElement.parentNode.nodeName === 'VAADIN-CHECKBOX') {
+        ctrlKey = true;
+    }
     // if click select only this row
     if (!ctrlKey && !e.shiftKey) {
         if (this.$server) {


### PR DESCRIPTION
# Add support for persistent checkbox-based selection

This PR introduces two new configuration options to enhance selection behavior in SelectionGrid:
- is/setMultiSelectionColumnVisible: Controls the visibility of the checkbox selection column.
- is/setPersistentCheckboxSelection: When enabled, selecting a row via its checkbox will add or remove it from the current selection without clearing previously selected rows. This behavior allows users to manage selections manually using checkboxes, similar to how email clients like Gmail handle selection.

By default, clicking a checkbox in the selection column clears the current selection and selects only the clicked row. With persistentCheckboxSelection enabled, checkboxes act as toggles, adding or removing rows from the selection without affecting other selected rows.